### PR TITLE
Due to the fix for #1248, X and Y probe offsets must not be floats.

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -392,6 +392,7 @@ const bool Z_MAX_ENDSTOP_INVERTING = true; // set to true to invert the logic of
 
 
   // these are the offsets to the probe relative to the extruder tip (Hotend - Probe)
+  // X and Y offsets must be integers
   #define X_PROBE_OFFSET_FROM_EXTRUDER -25
   #define Y_PROBE_OFFSET_FROM_EXTRUDER -29
   #define Z_PROBE_OFFSET_FROM_EXTRUDER -12.35


### PR DESCRIPTION
The compiler does not support comparing float values: "error: floating constant in preprocessor expression"
The loss in X/Y precision won't matter for Z probes, as most microswitches or inductive sensors are larger than 1mm square anyway.