### PR TITLE
temperature.cpp: Fix typo of MAX_BED_PID to MAX_BED_POWER.

### DIFF
--- a/Marlin/temperature.cpp
+++ b/Marlin/temperature.cpp
@@ -566,7 +566,7 @@ void manage_heater()
 		  temp_dState_bed = pid_input;
 
 		  pid_output = pTerm_bed + iTerm_bed - dTerm_bed;
-          	  if (pid_output > MAX_BED_PID) {
+          	  if (pid_output > MAX_BED_POWER) {
             	    if (pid_error_bed > 0 )  temp_iState_bed -= pid_error_bed; // conditional un-integration
                     pid_output=PID_MAX;
           	  } else if (pid_output < 0){

--- a/Marlin/temperature.cpp
+++ b/Marlin/temperature.cpp
@@ -568,7 +568,7 @@ void manage_heater()
 		  pid_output = pTerm_bed + iTerm_bed - dTerm_bed;
           	  if (pid_output > MAX_BED_POWER) {
             	    if (pid_error_bed > 0 )  temp_iState_bed -= pid_error_bed; // conditional un-integration
-                    pid_output=PID_MAX;
+                    pid_output=PID_BED_POWER;
           	  } else if (pid_output < 0){
             	    if (pid_error_bed < 0 )  temp_iState_bed -= pid_error_bed; // conditional un-integration
                     pid_output=0;


### PR DESCRIPTION
Fixes the comments on https://github.com/ErikZalm/Marlin/commit/984177c40cd3d6dc897d8f11407d6c424037843e#commitcomment-9131419
 
Compiles under Arduino 1.0.6 against a Arduino Mega 2560

Apologies for the incompletely tested earlier pull request.