### PR TITLE
Readd .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,38 @@
+---
+language: c
+
+before_install:
+  - pwd
+  - wget https://bootstrap.pypa.io/get-pip.py
+  - wget https://bintray.com/artifact/download/olikraus/u8glib/u8glib_arduino_v1.17.zip
+install:
+  - sudo python get-pip.py
+  - sudo pip install ino
+  # add ppa for newer version of Arduino than available in ubuntu 12.04
+  - sudo add-apt-repository ppa:michael-gruz/elektronik -y
+  - sudo apt-get update -q 
+  - sudo apt-get install arduino
+before_script:
+ # add U8glib, LiquidCrystal_I2C & LiquidTWI2 libraries 
+  - sudo unzip u8glib_arduino_v1.17.zip -d /usr/share/arduino/libraries/
+  - cd /usr/share/arduino/libraries/
+  - sudo git clone https://github.com/kiyoshigawa/LiquidCrystal_I2C.git
+  - ls -la
+  - ls -la LiquidCrystal_I2C/
+  - sudo git clone https://github.com/lincomatic/LiquidTWI2.git
+  # remove Robot_Control library to stop compile error!
+  - sudo rm -rf /usr/share/arduino/libraries/Robot_Control
+  # change back to home directory for compiling
+  - cd /home/travis/build/monkeydave/Marlin
+  # ino needs files in src directory
+  - ln -s Marlin src
+  # remove Marlin.pde as it confuses ino
+  - rm Marlin/Marlin.pde
+script:
+  - ino build -m mega2560
+  - cp Marlin/example_configurations/delta/Configuration* Marlin/
+  - rm -rf .build/
+  - ino build -m mega2560
+  - sed -i 's/#define MOTHERBOARD BOARD_RAMPS_13_EFB/#define MOTHERBOARD BOARD_DUEMILANOVE_328P/g' Marlin/Configuration.h
+  - rm -rf .build/
+  - ino build -m atmega328

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,10 +23,10 @@ before_script:
   # remove Robot_Control library to stop compile error!
   - sudo rm -rf /usr/share/arduino/libraries/Robot_Control
   # change back to home directory for compiling
-  - cd /home/travis/build/monkeydave/Marlin
+  - cd /home/travis/build/ErikZalm/Marlin
   # ino needs files in src directory
   - ln -s Marlin src
-  # remove Marlin.pde as it confuses ino
+  # remove Marlin.pde as it confuses ino after it finds Marlin.ino
   - rm Marlin/Marlin.pde
 script:
   - ino build -m mega2560


### PR DESCRIPTION
This file was removed in commit 95429a4108775f319bbe0b853c6fef711580e30a 

At the moment the Travis-Ci build passing image points to a build from 5 days ago as there is no longer a .travis.yml file in the repo.

This file isn't the same as the one removed the other day, I have changed the travis.yml file to use ino the command line compiler for Arduino as I couldn't easily get the Makefile to work with the U8glib library so I decided to use ino instead.

It should now be easy to add commands to the script: part of the travis.yml file and check compilation with different boards and with extra options defined in Configuration.h and Configuration_adv.h whch will hopefully create a more stable Marlin going forward. The previous travis.yml file only checked the default config with an ultimaker board, its never going to pick up most of the compile errors when people are adding in stuff that doesn't get compiled in automatically with the default configuration.

Check https://travis-ci.org/monkeydave/Marlin/builds for the build history of my branch as it will fail at the moment because I had to change the directory to ErikZalm so it will compile when/if it is merged.

I am happy to add more compile options but didn't want to waste my time if this doesn't get merged in.