### PR TITLE
Redefine PROGMEM and PSTR to omit buggy avr-g++ warnings

### DIFF
--- a/Marlin/LiquidCrystalRus.cpp
+++ b/Marlin/LiquidCrystalRus.cpp
@@ -1,9 +1,6 @@
 #include "LiquidCrystalRus.h"
 
-#include <stdio.h>
-#include <string.h>
-#include <inttypes.h>
-#include <avr/pgmspace.h>
+#include "Marlin.h"
 
 #if defined(ARDUINO) && ARDUINO >= 100
   #include "Arduino.h"

--- a/Marlin/Marlin.h
+++ b/Marlin/Marlin.h
@@ -14,6 +14,16 @@
 
 #include <util/delay.h>
 #include <avr/pgmspace.h>
+
+#define GCC_VERSION (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
+/* Omit buggy avr-g++ warnings. It's gcc bug 34734.  */
+#if GCC_VERSION < 40602
+#undef PROGMEM
+#undef PSTR
+#define PROGMEM __attribute__((section (".progmem.data")))
+#define PSTR(s) (__extension__ ({static const char __c[] PROGMEM = (s); &__c[0];}))
+#endif
+
 #include <avr/eeprom.h>
 #include <avr/interrupt.h>
 
@@ -270,3 +280,4 @@ extern void digipot_i2c_init();
 #endif
 
 extern void calculate_volumetric_multipliers();
+


### PR DESCRIPTION
arduino 1.0.5 / 1.0.6 uses avr-g++ 4.3.2 which is affected by gcc bug 34734. 
(avr-gcc doesn't have this bug. It's  avr-g++ specific bug because avr-g++ isn't supported.)
This pull request is a hack to work around it.
Tested on Prusa i3.