### PR TITLE
temp runaway: proper cast to prevent any overflow.

### DIFF
--- a/Marlin/temperature.cpp
+++ b/Marlin/temperature.cpp
@@ -1049,7 +1049,7 @@ void thermal_runaway_protection(int *state, unsigned long *timer, float temperat
       {
         *timer = millis();
       } 
-      else if ( (millis() - *timer) > period_seconds*1000)
+      else if ( (millis() - *timer) > ((unsigned long) period_seconds) * 1000)
       {
         SERIAL_ERROR_START;
         SERIAL_ERRORLNPGM("Thermal Runaway, system stopped! Heater_ID: ");


### PR DESCRIPTION
Hello,
(this time pull request to Dev branch, sorry about the multiple attemps)

I noticed that the temp runaway feature was not working any more in my environment:
avr-gcc (GCC) 4.9.2
avr-libc 1.8.1
arduino 1.0.5
Mendel90 + Melzi

After digging, I noticed that the operation (millis() - timer) > period_seconds1000 was always returning false, hence the proposed fix. It cast to (unsigned long) to be of the same type as millis().

Tested by setting the hotend temperature, waiting for it to be reached, and unplugging the heater wire. On the Stable branch, nothing happens, while with this fix the runaway protection fires after the desired amount of time.

This branch is based on the merge-base from Stable and Development branches.
Thanks